### PR TITLE
Relax minitest version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,6 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'sqlite3'
-gem 'minitest', '< 5.3.4'
 gem 'bcrypt'
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 


### PR DESCRIPTION
This PR fixes `PersistenceTest` where `assert_raises` also [matches subclasses](https://github.com/seattlerb/minitest/blob/master/History.rdoc#570--2015-05-27).

This change might also break other tests once they're now executed randomically. Fixing this order dependency of the tests should be approached in another PR.  

```
PersistenceTest#test_destroy_new_record [test/cases/persistence_test.rb:658]
PersistenceTest#test_delete_new_record [test/cases/persistence_test.rb:633]
```